### PR TITLE
removed white bars which appeared in vimium v1.66

### DIFF
--- a/vimium-dracula.css
+++ b/vimium-dracula.css
@@ -32,6 +32,10 @@ div > .vimiumHintMarker > .matchingCharacter {
   color: #6272a4;
 }
 
+#vomnibar{
+    background-color: #44475A;
+}
+
 #vomnibar input {
   color: #f8f8f2;
   font: -moz-window;
@@ -63,6 +67,8 @@ div > .vimiumHintMarker > .matchingCharacter {
   list-style: none;
   padding: 10px 0;
   padding-top: 0;
+  margin-block-start: 2px;
+  margin-block-end: 0px;
 }
 
 #vomnibar li {


### PR DESCRIPTION
Vimium v1.66 was released on 2020-03-03, and included larger top and bottom margins in the vomnibar. These margins were colored white (#F1F1F1), so did not match the dracula theme. This pull request fixes this by setting the background of these margins to match the rest of the vomnibar (#44475a), and also makes them smaller.