### PR TITLE
Colors for HUD ('heads-up display') bar

### DIFF
--- a/vimium-dracula.css
+++ b/vimium-dracula.css
@@ -32,6 +32,34 @@ div > .vimiumHintMarker > .matchingCharacter {
   color: #6272a4;
 }
 
+/* HUD ("heads-up display") bar */
+div.vimiumHUD {
+  background: #282a36;
+  border: 1px solid #6272a4;
+}
+
+div.vimiumHUD .vimiumHUDSearchArea {
+  background: #282a36;
+}
+
+div.vimiumHUD .hud-find {
+  background: #282a36;
+  border: none;
+  color: #f8f8f2;
+}
+
+div.vimiumHUD span#hud-find-input{
+  color: #f8f8f2;  /* 'Foreground' color */
+}
+
+div.vimiumHUD span#hud-match-count {
+  color: #6272a4;  /* 'Comment' color */
+}
+
+div.vimiumHUD .vimiumHUDSearchAreaInner {
+  color: #6272a4;  /* 'Comment' color */
+}
+
 #vomnibar{
     background-color: #44475A;
 }
@@ -76,7 +104,7 @@ div > .vimiumHintMarker > .matchingCharacter {
   line-height: 1.1em;
   padding: 7px 10px;
   font-size: 16px;
-  color: f8f8f2;
+  color: #f8f8f2;
   position: relative;
   display: list-item;
   margin: auto;


### PR DESCRIPTION
The HUD bar is currently just the default (black on white). Here are some small screen shots of the updates. 

![image](https://user-images.githubusercontent.com/34973839/97645912-94a63f00-1a24-11eb-902b-e631860ea92a.png)

What you type is the 'Forground' color while generated text is the 'Comment' color. 

![image](https://user-images.githubusercontent.com/34973839/97646003-dc2ccb00-1a24-11eb-9c68-814f9476d662.png)

Here's one on a dark theme background: 

![image](https://user-images.githubusercontent.com/34973839/97646128-37f75400-1a25-11eb-8d53-4d1c3a4bbe98.png)

I've tested on Chrome and Firefox. (Edit: vimium 1.66)

Will not be offended at all if you don't want to merge this. I"m not that good at CSS. :) Just wanted to offer what I did for myself. 
